### PR TITLE
Downgrade OpenTelemetry. Fix dependency conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,18 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <slf4j.version>2.0.17</slf4j.version>
-    <otel.version>1.53.0</otel.version>
+    <!--
+    The Quarkus BOM brings in its own versions of okhttp3 (3.14.9) and okio (1.17.2) and kotlin (1.7.22).
+    This conflicts with the OpenTelemetry versions. We can't update to 1.52/1.53 as it causes major conflicts
+    in Kotlin when building with Gradle (Protocol message contained an invalid tag (zero))
+    1.53 : okhttp 5.1.0 ( okio 3.15.0, kotlin-stdlib 2.2.0)
+    1.52 : okhttp 5.1.0 ( okio 3.15.0, kotlin-stdlib 2.2.0)
+    1.51 : okhttp 4.12.0 ( okio 3.6.0, kotlin-stdlib 1.8.21)
+    1.40 : okhttp 4.12.0 ( okio 3.6.0, kotlin-stdlib 1.8.21)
+    1.29 : okhttp 4.11.0 ( okio 3.2.0, kotlin-stdlib 1.6.20)
+    -->
+    <otel.version>1.51.0</otel.version>
+    <quarkus.version>2.16.12.Final</quarkus.version>
   </properties>
 
   <dependencyManagement>
@@ -79,9 +90,24 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>4.12.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>3.6.0</version>
+      </dependency>
+      <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-semconv</artifactId>
         <version>1.29.0-alpha</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.platform</groupId>
@@ -106,12 +132,6 @@
         <groupId>uk.org.webcompere</groupId>
         <artifactId>system-stubs-core</artifactId>
         <version>2.1.8</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.rest-assured</groupId>
-        <artifactId>rest-assured</artifactId>
-        <version>4.4.0</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -175,7 +195,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+      <artifactId>quarkus-opentelemetry</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -219,7 +239,7 @@
             </sortPom>
           </pom>
           <java>
-            <removeUnusedImports />
+            <removeUnusedImports/>
             <importOrder>
               <file>java-import-order.txt</file>
             </importOrder>


### PR DESCRIPTION
This **downgrades** OpenTelemetry from 1.53 to 1.51. The reason for this is that 1.52/1.53 had a significant update to okhttp/okio which then brings in kotlin-stdlib 2.2.0. This heavily conflicts with Gradle builds in https://github.com/project-ncl/gradle-manipulator (as Gradle bundles its own Kotlin versions we end up getting in CI tests e.g.
```
      Caused by: org.jetbrains.kotlin.protobuf.InvalidProtocolBufferException: Protocol message contained an invalid tag (zero).
        at org.jetbrains.kotlin.protobuf.InvalidProtocolBufferException.invalidTag(InvalidProtocolBufferException.java:89)
        at org.jetbrains.kotlin.protobuf.CodedInputStream.readTag(CodedInputStream.java:158)
        at org.jetbrains.kotlin.metadata.jvm.JvmModuleProtoBuf$Module.<init>(JvmModuleProtoBuf.java:188)
        at org.jetbrains.kotlin.metadata.jvm.JvmModuleProtoBuf$Module.<init>(JvmModuleProtoBuf.java:153)
        at org.jetbrains.kotlin.metadata.jvm.JvmModuleProtoBuf$Module$1.parsePartialFrom(JvmModuleProtoBuf.java:295)
        at org.jetbrains.kotlin.metadata.jvm.JvmModuleProtoBuf$Module$1.parsePartialFrom(JvmModuleProtoBuf.java:290)
        at org.jetbrains.kotlin.protobuf.AbstractParser.parsePartialFrom(AbstractParser.java:192)
        at org.jetbrains.kotlin.protobuf.AbstractParser.parseFrom(AbstractParser.java:209)
        at org.jetbrains.kotlin.protobuf.AbstractParser.parseFrom(AbstractParser.java:215)
        at org.jetbrains.kotlin.protobuf.AbstractParser.parseFrom(AbstractParser.java:49)
        at org.jetbrains.kotlin.metadata.jvm.JvmModuleProtoBuf$Module.parseFrom(JvmModuleProtoBuf.java:685)
        at org.jetbrains.kotlin.metadata.jvm.deserialization.ModuleMapping$Companion.loadModuleMapping(ModuleMapping.kt:70)
        at org.jetbrains.kotlin.load.kotlin.ModuleMappingUtilKt.loadModuleMapping(ModuleMappingUtil.kt:18)
        at org.jetbrains.kotlin.cli.jvm.compiler.JvmPackagePartProviderKt.tryLoadModuleMapping(JvmPackagePartProvider.kt:72)
        at org.jetbrains.kotlin.cli.jvm.compiler.JvmPackagePartProvider.addRoots(JvmPackagePartProvider.kt:54)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.createPackagePartProvider(KotlinCoreEnvironment.kt:293)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$analyze$1$1.invoke(KotlinToJVMBytecodeCompiler.kt:559)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$analyze$1$1.invoke(KotlinToJVMBytecodeCompiler.kt:81)
        at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.createContainer(TopDownAnalyzerFacadeForJVM.kt:176)
        at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(TopDownAnalyzerFacadeForJVM.kt:84)
        at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration$default(TopDownAnalyzerFacadeForJVM.kt:82)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$analyze$1.invoke(KotlinToJVMBytecodeCompiler.kt:554)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$analyze$1.invoke(KotlinToJVMBytecodeCompiler.kt:81)
        at org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport.analyzeAndReport(AnalyzerWithCompilerReport.kt:107)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.analyze(KotlinToJVMBytecodeCompiler.kt:545)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.analyzeAndGenerate(KotlinToJVMBytecodeCompiler.kt:527)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileBunchOfSources(KotlinToJVMBytecodeCompiler.kt:426)
        at org.gradle.kotlin.dsl.support.KotlinCompilerKt.compileKotlinScriptModuleTo(KotlinCompiler.kt:176)
        at org.gradle.kotlin.dsl.support.KotlinCompilerKt.compileKotlinScriptToDirectory(KotlinCompiler.kt:136)
        at org.gradle.kotlin.dsl.execution.ResidualProgramCompiler$compileScript$1.invoke(ResidualProgramCompiler.kt:648)
        at org.gradle.kotlin.dsl.execution.ResidualProgramCompiler$compileScript$1.invoke(ResidualProgramCompiler.kt:82)
        at org.gradle.kotlin.dsl.provider.StandardKotlinScriptEvaluator$InterpreterHost$runCompileBuildOperation$1.call(KotlinScriptEvaluator.kt:165)
        at org.gradle.kotlin.dsl.provider.StandardKotlinScriptEvaluator$InterpreterHost$runCompileBuildOperation$1.call(KotlinScriptEvaluator.kt:162)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$CallableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:409)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$CallableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:399)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:157)
```


Further importing the Quarkus bom is required for the tests but that brings in its own versions of okhttp/okio and kotlin which also confuses the dependency matrix hence overriding with the explicit versions from OpenTelemetry poms.

The other minor changes are:

- Use the version of rest-assured from Quarkus.
- Use the relocated groupId